### PR TITLE
add new method to get comments of given post

### DIFF
--- a/psaw/PushshiftAPI.py
+++ b/psaw/PushshiftAPI.py
@@ -114,10 +114,12 @@ class PushshiftAPIMinimal(object):
 
     def _comments(self, kind, **kwargs):
         base36_id = kwargs.get('base36_id', None)
-        if base36_id: 
+        limit = kwargs.get('limit', None)
+        if base36_id and limit:
+                del kwargs['base36_id']
                 url = self.base_url.format(kind) + 'comment_ids/' + base36_id
         else:
-                raise ValueError('Invalid Argument: must provide id of the post, base36_id = <your id>')
+                raise ValueError('Invalid Argument: must provide id of the post and limit')
                 return
         i, success = 0, False
         while (not success) and (i<self.max_retries):
@@ -128,6 +130,7 @@ class PushshiftAPIMinimal(object):
         response_json = json.loads(response.text)
         outv = response_json['data']
         params = {'ids' : outv}
+        params.update(kwargs)
         return self._query(kind='comment', **params)
         
 


### PR DESCRIPTION
The method takes base36 id of the post, and returns the comments.
Internally, it first calls a submission to get ids of all the comments of given post. Then its simply calling a self._query t get all the comments.

As a wrapper around Pushshift, I think this is a must have functionality.
##############################################################################
Update_1: Apparently, to use this API, user has to enter the limit. This limit can be greater than number of comments in the post. It is required because the way _query works. There is no way to exit the function, because as of now it assumes that get returns results sorted with respect to time. This may not be true if user sends sort_type='score' parameter. 