### PR TITLE
fix for paging

### DIFF
--- a/psaw/PushshiftAPI.py
+++ b/psaw/PushshiftAPI.py
@@ -203,7 +203,10 @@ class PushshiftAPIMinimal(object):
                 yield batch
 
             # For paging.
-            self.payload['before'] = thing.created_utc
+            if self.payload.get('sort') == 'desc':
+                self.payload['before'] = thing.created_utc
+            else:
+                self.payload['after'] = thing.created_utc
 
 
 #class PushshiftAPI(PushshiftAPIMinimal):


### PR DESCRIPTION
This is a fix for #7 . It works when before/after are provided with either sort value, as long as a valid value for sort, either `asc` or `desc`, is provided.

It looks like @typenil had implemented a [similar solution](https://github.com/typenil/psaw/blob/master/psaw/pushshift_api_minimal.py#L180) in his/her fork.

By the way, I noticed while testing that the following code returns too many results:

```
api.search_comments(before=1135640628, sort='badSortValue')
## returns 999 comments
```

Pushshift gives the expected result from [this query](https://api.pushshift.io/reddit/comment/search/?size=1000&sort=badSortValue&before=1135640628), 534 comments.
