### PR TITLE
Allow fewer fields when fetching data

### DIFF
--- a/psaw/PushshiftAPI.py
+++ b/psaw/PushshiftAPI.py
@@ -111,7 +111,8 @@ class PushshiftAPIMinimal(object):
 
     def _wrap_thing(self, thing, kind):
         """Mimic praw.Submission and praw.Comment API"""
-        thing['created'] = self._epoch_utc_to_local(thing['created_utc'])
+        if 'created_utc' in thing:
+            thing['created'] = self._epoch_utc_to_local(thing['created_utc'])
         thing['d_'] = copy.deepcopy(thing)
         ThingType = namedtuple(kind, thing.keys())
         thing = ThingType(**thing)
@@ -219,10 +220,11 @@ class PushshiftAPIMinimal(object):
                 yield batch
 
             # For paging.
-            if self.payload.get('sort') == 'desc':
-                self.payload['before'] = thing.created_utc
-            else:
-                self.payload['after'] = thing.created_utc
+            if hasattr(thing, "created_utc"):
+                if self.payload.get('sort') == 'desc':
+                    self.payload['before'] = thing.created_utc
+                else:
+                    self.payload['after'] = thing.created_utc
 
 
 #class PushshiftAPI(PushshiftAPIMinimal):


### PR DESCRIPTION
One of the arguments to the api is the `fields` parameter that allows the list of fields to be reduced. At the moment, I have to include the `created_utc`, even if it's not necessary.

This is an example of a query that would have failed but now succeeds:
```
>>> from psaw import PushshiftAPI
>>> api = PushshiftAPI()
>>> print(list(api.search_submissions(subreddit="cursedimages", fields=["url"], limit=10)))
[submission(url='https://i.redd.it/1gt4asygyyr31.jpg', d_={'url': 'https://i.redd.it/1gt4asygyyr31.jpg'}), submission(url='https://i.redd.it/jy6qrnb9yyr31.jpg', d_={'url': 'https://i.redd.it/jy6qrnb9yyr31.jpg'}),
...]
```