### PR TITLE
Resolving TypeError

### DIFF
--- a/psaw/PushshiftAPI.py
+++ b/psaw/PushshiftAPI.py
@@ -185,7 +185,7 @@ class PushshiftAPIMinimal(object):
                 log.info(response.url)
                 log.debug('Response status code: %s' % response.status_code)
             except requests.ConnectionError:
-                log.debug("Connection error caught, retrying. Connection attempts so far: %s" % i+1)
+                log.debug("Connection error caught, retrying. Connection attempts so far: %s" % str(i+1))
                 continue
             success = response.status_code == 200
             if not success:


### PR DESCRIPTION
I hit an error 
> psaw ConnectionResetError: [WinError 10054] An existing connection was forcibly closed by the remote host
On inspecting the stack trace there were a couple of exceptions the final of which was not handled and terminated the program.
Final error
> log.debug("Connection error caught, retrying. Connection attempts so far: %s" % i+1)
> TypeError: can only concatenate str (not "int") to str
I did not capture the full stack trace at the time and am currently unable to replicate but it was resolved with the proposed change.