### PR TITLE
Refactored RateLimitCache to work on a per second basis, rather than per minute

### DIFF
--- a/psaw/PushshiftAPI.py
+++ b/psaw/PushshiftAPI.py
@@ -167,7 +167,7 @@ class PushshiftAPIMinimal(object):
                 log.info(response.url)
                 log.debug('Response status code: %s' % response.status_code)
             except (requests.ConnectionError, requests.Timeout) as e:
-                log.debug(f"Network error: {e}, Retrying ({i + 1}/{self.max_retries}")
+                warnings.warn(f"Network Error: {e}, Retrying ({i + 1}/{self.max_retries}")
                 continue
             success = response.status_code == 200
             if not success:


### PR DESCRIPTION
This adheres to the current Pushshift API rate-limit of 1 request per second.

[https://pypi.org/project/pushshift.py](https://pypi.org/project/pushshift.py)
> A minimum rate limit of 1 request per second is used as a default per consultation with Pushshift’s maintainer, /u/Stuck_in_the_matrix.