### PR TITLE
Made the download aware of the actual returned batch size when using limit

### DIFF
--- a/psaw/PushshiftAPI.py
+++ b/psaw/PushshiftAPI.py
@@ -212,9 +212,15 @@ class PushshiftAPIMinimal(object):
                     raise NotImplementedError(err_msg.format(self.max_results_per_request))
             self._add_nec_args(self.payload)
 
-            yield self._get(url, self.payload)
+            data = self._get(url, self.payload)
+            yield data
+            received_size = int(data['metadata']['size'])
+            requested_size = self.payload['limit']
+            # Apparently the API can decide to send less data than desired. We need to send another request in that case
+            if received_size < requested_size:
+                limit += requested_size - received_size
 
-            if (limit is not None) & (limit == 0):
+            if (limit is not None) and (limit == 0):
                 return
 
     def _search(self,

--- a/psaw/PushshiftAPI.py
+++ b/psaw/PushshiftAPI.py
@@ -214,14 +214,16 @@ class PushshiftAPIMinimal(object):
 
             data = self._get(url, self.payload)
             yield data
-            received_size = int(data['metadata']['size'])
-            requested_size = self.payload['limit']
-            # Apparently the API can decide to send less data than desired. We need to send another request in that case
-            if received_size < requested_size:
-                limit += requested_size - received_size
+            if limit is not None:
+                received_size = int(data['metadata']['size'])
+                requested_size = self.payload['limit']
+                # The API can decide to send less data than desired.
+                # We need to send another request in that case requesting the missing amount
+                if received_size < requested_size:
+                    limit += requested_size - received_size
 
-            if (limit is not None) and (limit == 0):
-                return
+                if limit == 0:
+                    return
 
     def _search(self,
                 kind,


### PR DESCRIPTION
Fix for issue #79 .
Right now the download is not aware that the API can return less elements than requested. This causes the result to be less than expected when the "limit" is higher than the returned size.