### PR TITLE
Set 'sort' based on use of 'before' or 'after'

### DIFF
--- a/psaw/PushshiftAPI.py
+++ b/psaw/PushshiftAPI.py
@@ -161,7 +161,10 @@ class PushshiftAPIMinimal(object):
             payload['metadata'] = 'true'
         if 'sort' not in payload:
             # Getting weird results if this is not made explicit. Unclear why.
-            payload['sort'] = 'desc'
+            if 'after' in payload:
+                payload['sort'] = 'asc'
+            else:
+                payload['sort'] = 'desc'
         if 'filter' in payload: #and payload.get('created_utc', None) is None:
             if not isinstance(payload['filter'], list):
                 if isinstance(payload['filter'], str):


### PR DESCRIPTION
Resolves https://github.com/dmarx/psaw/issues/94

This gives the most intuitive results when using either 'before' or 'after' references, and brings the code in line with documentation that already exists.

https://github.com/dmarx/psaw/blob/master/docs/source/index.rst#first-10-submissions-to-rpolitics-in-2017-filtering-results-to-urlauthortitlesubreddit-fields

